### PR TITLE
Raise JQ::Error on JQ runtime error

### DIFF
--- a/spec/jq_spec.rb
+++ b/spec/jq_spec.rb
@@ -229,11 +229,11 @@ describe JQ do
 
     expect(searched.length).to eq(1)
     expect(searched[0]).to be_kind_of(String)
-    expect(JSON.parse(searched[0])).to eq(JSON.parse(expected))
+    expect(MultiJson.load(searched[0])).to eq(MultiJson.load(expected))
 
     JQ(src, :parse_json => false).search('.') do |value|
       expect(value).to be_kind_of(String)
-      expect(JSON.parse(value)).to eq(JSON.parse(expected))
+      expect(MultiJson.load(value)).to eq(MultiJson.load(expected))
     end
   end
 
@@ -267,6 +267,14 @@ describe JQ do
         raise 'runtime error'
       end
     }.to raise_error(RuntimeError)
+  end
+
+  it 'runtime halt in jq raises error' do
+    expect {
+      JQ('{}').search('.data | keys') do |value|
+        value
+      end
+    }.to raise_error(JQ::Error).with_message('null (null) has no keys')
   end
 
   it 'query for hash' do


### PR DESCRIPTION
JQ Runtime Errors are currently silently swallowed and `nil` is returned from the parser.  This seems like the incorrect behavior - the `jq` binary and jqplay.org both exit with status 5 on builtin `halts` or runtime errors in the JQ program.  The easiest example I could find was this:

```jq
.a_non_existent_key | keys
```

In the CLI this will exit with status 5 and the `null (null) has no keys` error.  Admittedly this is not terribly helpful - but that is what JQ gives us.

In the current version the C code swallows the error - if the `jq_process` function sets `result` to a `jv` with an invalid msg - this is never checked (and since the jv is copied and freed before being returned to the calling function, the error is invisible to the caller.)

This patch simple passes the `errmsg` pointer down the call stack another level and performs the same "has an invalid message" check on the `jv result` when the while loop fails.