### PR TITLE
Use mini_portile2 in extconf.rb

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,19 +7,12 @@ see [http://stedolan.github.io/jq/](http://stedolan.github.io/jq/).
 [![Gem Version](https://badge.fury.io/rb/ruby-jq.svg)](http://badge.fury.io/rb/ruby-jq)
 [![Build Status](https://travis-ci.org/winebarrel/ruby-jq.svg?branch=master)](https://travis-ci.org/winebarrel/ruby-jq)
 
+## Prerequisites
+
+jq requires the Oniguruma library to provide regex support. To install Oniguruma
+for your system, please follow the instructions in the [jq FAQ](https://github.com/stedolan/jq/wiki/FAQ#installation).
+
 ## Installation
-
-First, please install libjq from HEAD of [git repository](https://github.com/stedolan/jq).
-
-```sh
-git clone https://github.com/stedolan/jq.git
-cd jq
-autoreconf -i
-./configure --enable-shared
-make
-sudo make install
-sudo ldconfig
-```
 
 Add this line to your application's Gemfile:
 
@@ -32,6 +25,13 @@ And then execute:
 Or install it yourself as:
 
     $ gem install ruby-jq
+
+### Using system libraries
+
+By default, ruby-jq downloads and compiles its own version of libjq. If you
+would like to use your own version of libjq, you can skip this process by
+passing the `--use-system-libraries` flag to `gem install`, or by setting the
+`RUBYJQ_USE_SYSTEM_LIBRARIES` env var.
 
 ## Usage
 

--- a/ext/extconf.rb
+++ b/ext/extconf.rb
@@ -1,5 +1,33 @@
 require 'mkmf'
 
-if have_library('jq')
-  create_makefile('jq_core')
+def using_system_libraries?
+  arg_config('--use-system-libraries', !!ENV['RUBYJQ_USE_SYSTEM_LIBRARIES'])
 end
+
+unless using_system_libraries?
+  message "Buildling jq using packaged libraries.\n"
+
+  require 'rubygems'
+  require 'mini_portile2'
+
+  recipe = MiniPortile.new("jq", "1.6")
+  recipe.files = ["https://github.com/stedolan/jq/archive/jq-1.6.tar.gz"]
+  recipe.configure_options = [
+    "--enable-shared",
+    "--disable-maintainer-mode"
+  ]
+  class << recipe
+    def configure
+      execute("autoreconf", "autoreconf -i")
+      super
+    end
+  end
+  recipe.cook
+  recipe.activate
+  $LIBPATH = ["#{recipe.path}/lib"] | $LIBPATH
+  $CPPFLAGS << " -I#{recipe.path}/include"
+end
+
+abort "libjq not found" unless have_library('jq')
+
+create_makefile('jq_core')

--- a/ruby-jq.gemspec
+++ b/ruby-jq.gemspec
@@ -20,6 +20,8 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "multi_json"
+  spec.add_runtime_dependency "mini_portile2", ">= 2.2.0"
+
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rake-compiler"


### PR DESCRIPTION
I wanted to make installing this gem easier and require fewer manual steps. I noticed that the current extconf.rb simply checks for the existence of libjq on the host, which means that the user has to manage their own installation of libjq in order to use this gem.

In this PR, I updated extconf.rb to use mini_portile2 to automatically download and compile libjq. The code was based on how the gem [ruby-jsonnet](https://github.com/yugui/ruby-jsonnet/blob/master/ext/jsonnet/extconf.rb) handles compiling libjsonnet. I tested installing the gem locally with `rake install` and `gem install` and both worked for me.

I also added the ability to skip downloading and compiling the library by specifying the flag `--use-system-libraries`, in case anyone installing the gem wants to use their own compiled version of libjq.

One wrinkle that I encountered was that libjq requires the Oniguruma library to provide regex support. The jq Git repo includes the Oniguruma Git repo as a submodule, but downloading the jq repo as a tarball from source doesn't include the submodules in it. So that means in order to create the package libjq, the host needs to already have Oniguruma installed on it. The [jq wiki's section on building from source](https://github.com/stedolan/jq/wiki/Installation#or-build-from-source) actually indicates that installing Oniguruma separately is a requirement, so I think this makes sense.