### PR TITLE
Make it build again

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,8 +1,8 @@
 AllCops:
   Exclude:
     - 'tmp/**/*'
-  TargetRubyVersion: 2.3
-Metrics/LineLength:
+  TargetRubyVersion: 2.7
+Layout/LineLength:
   Enabled: false
 Metrics/BlockLength:
   Enabled: false

--- a/ext/extconf.rb
+++ b/ext/extconf.rb
@@ -12,10 +12,28 @@ unless using_system_libraries?
   require 'rubygems'
   require 'mini_portile2'
 
+  onig_recipe = MiniPortile.new('onigmo', '6.2.0')
+  onig_recipe.files << 'https://github.com/k-takata/Onigmo/releases/download/Onigmo-6.2.0/onigmo-6.2.0.tar.gz'
+  onig_recipe.configure_options = [
+    '--disable-static',
+    '--disable-maintainer-mode'
+  ]
+  class << onig_recipe
+    def configure
+      execute('autoreconf', 'autoreconf -vfi')
+      super
+    end
+  end
+  onig_recipe.cook
+  onig_recipe.activate
+  $LIBPATH = ["#{onig_recipe.path}/lib"] | $LIBPATH # rubocop:disable Style/GlobalVars
+  $CPPFLAGS << " -I#{onig_recipe.path}/include" # rubocop:disable Style/GlobalVars
+
   recipe = MiniPortile.new('jq', '1.6')
-  recipe.files = ['https://github.com/stedolan/jq/releases/download/jq-1.6/jq-1.6.tar.gz']
+  recipe.files = ['https://github.com/stedolan/jq/archive/cff5336ec71b6fee396a95bb0e4bea365e0cd1e8.tar.gz']
+  recipe.patch_files << File.join(File.dirname(File.expand_path(__FILE__)), "jq-onigmo.patch")
   recipe.configure_options = [
-    '--enable-shared',
+    '--disable-static',
     '--disable-maintainer-mode'
   ]
   class << recipe
@@ -27,7 +45,7 @@ unless using_system_libraries?
   end
   recipe.cook
   recipe.activate
-  $LIBPATH = ["#{recipe.path}/lib"] | $LIBPATH # rubocop:disable Style/GlobalVars
+  $LIBPATH = ["#{onig_recipe.path}/lib", "#{recipe.path}/lib"] | $LIBPATH # rubocop:disable Style/GlobalVars
   $CPPFLAGS << " -I#{recipe.path}/include" # rubocop:disable Style/GlobalVars
 end
 

--- a/ext/extconf.rb
+++ b/ext/extconf.rb
@@ -31,7 +31,7 @@ unless using_system_libraries?
 
   recipe = MiniPortile.new('jq', '1.6')
   recipe.files = ['https://github.com/stedolan/jq/archive/cff5336ec71b6fee396a95bb0e4bea365e0cd1e8.tar.gz']
-  recipe.patch_files << File.join(File.dirname(File.expand_path(__FILE__)), "jq-onigmo.patch")
+  recipe.patch_files << File.join(File.dirname(File.expand_path(__FILE__)), 'jq-onigmo.patch')
   recipe.configure_options = [
     '--disable-static',
     '--disable-maintainer-mode'

--- a/ext/extconf.rb
+++ b/ext/extconf.rb
@@ -13,7 +13,7 @@ unless using_system_libraries?
   require 'mini_portile2'
 
   recipe = MiniPortile.new('jq', '1.6')
-  recipe.files = ['https://github.com/stedolan/jq/archive/jq-1.6.tar.gz']
+  recipe.files = ['https://github.com/stedolan/jq/releases/download/jq-1.6/jq-1.6.tar.gz']
   recipe.configure_options = [
     '--enable-shared',
     '--disable-maintainer-mode'

--- a/ext/extconf.rb
+++ b/ext/extconf.rb
@@ -20,7 +20,8 @@ unless using_system_libraries?
   ]
   class << recipe
     def configure
-      execute('autoreconf', 'autoreconf -i')
+      # https://github.com/stedolan/jq/issues/1778
+      execute('autoreconf', 'autoreconf -fi')
       super
     end
   end

--- a/ext/jq-onigmo.patch
+++ b/ext/jq-onigmo.patch
@@ -1,0 +1,62 @@
+--- configure.ac
++++ configure.ac
+@@ -270,10 +270,10 @@ AS_IF([test "x$with_oniguruma" != xno], [
+        # check for ONIGURUMA library, either in /usr or where requested
+        CFLAGS="$CFLAGS $onig_CFLAGS"
+        LDFLAGS="$LDFLAGS $onig_LDFLAGS"
+-       AC_CHECK_HEADER("oniguruma.h",
+-          AC_CHECK_LIB([onig],[onig_version]))
++       AC_CHECK_HEADER("onigmo.h",
++          AC_CHECK_LIB([onigmo],[onig_version]))
+        # handle check results
+-       AS_IF([test "x$ac_cv_lib_onig_onig_version" != "xyes"], [
++       AS_IF([test "x$ac_cv_lib_onigmo_onig_version" != "xyes"], [
+           build_oniguruma=yes
+           AC_MSG_NOTICE([Oniguruma was not found. Will use the packaged oniguruma.])
+        ])
+--- src/builtin.c
++++ src/builtin.c
+@@ -29,8 +29,8 @@ void *alloca (size_t);
+ #include <ctype.h>
+ #include <limits.h>
+ #include <math.h>
+-#ifdef HAVE_LIBONIG
+-#include <oniguruma.h>
++#ifdef HAVE_LIBONIGMO
++#include <onigmo.h>
+ #endif
+ #include <string.h>
+ #include <time.h>
+@@ -801,7 +801,7 @@ static jv f_group_by_impl(jq_state *jq, jv input, jv keys) {
+   }
+ }
+ 
+-#ifdef HAVE_LIBONIG
++#ifdef HAVE_LIBONIGMO
+ static int f_match_name_iter(const UChar* name, const UChar *name_end, int ngroups,
+     int *groups, regex_t *reg, void *arg) {
+   jv captures = *(jv*)arg;
+@@ -889,7 +889,7 @@ static jv f_match(jq_state *jq, jv input, jv regex, jv modifiers, jv testmode) {
+ 
+   onigret = onig_new(&reg, (const UChar*)jv_string_value(regex),
+       (const UChar*)(jv_string_value(regex) + jv_string_length_bytes(jv_copy(regex))),
+-      options, ONIG_ENCODING_UTF8, ONIG_SYNTAX_PERL_NG, &einfo);
++      options, ONIG_ENCODING_UTF8, ONIG_SYNTAX_PERL58_NG, &einfo);
+   if (onigret != ONIG_NORMAL) {
+     UChar ebuf[ONIG_MAX_ERROR_MESSAGE_LEN];
+     onig_error_code_to_str(ebuf, onigret, &einfo);
+@@ -1005,11 +1005,11 @@ static jv f_match(jq_state *jq, jv input, jv regex, jv modifiers, jv testmode) {
+   jv_free(regex);
+   return result;
+ }
+-#else /* !HAVE_LIBONIG */
++#else /* !HAVE_LIBONIGMO */
+ static jv f_match(jq_state *jq, jv input, jv regex, jv modifiers, jv testmode) {
+-  return jv_invalid_with_msg(jv_string("jq was compiled without ONIGURUMA regex library. match/test/sub and related functions are not available."));
++  return jv_invalid_with_msg(jv_string("jq was compiled without ONIGMO regex library. match/test/sub and related functions are not available."));
+ }
+-#endif /* HAVE_LIBONIG */
++#endif /* HAVE_LIBONIGMO */
+ 
+ static jv minmax_by(jv values, jv keys, int is_min) {
+   if (jv_get_kind(values) != JV_KIND_ARRAY)

--- a/ext/jq_core.c
+++ b/ext/jq_core.c
@@ -95,6 +95,7 @@ static void jq_process(jq_state *jq, jv value, VALUE (*proc)(), int *status, VAL
     if (*status == 0) {
       rb_protect(proc, rb_str_new2(str), status);
     }
+    jv_free(dumped);
   }
 
   if (jv_invalid_has_msg(jv_copy(result))) {

--- a/lib/jq/version.rb
+++ b/lib/jq/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module JQ
-  VERSION = '0.2.1'
+  VERSION = '0.2.2'
 end

--- a/lib/jq/version.rb
+++ b/lib/jq/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module JQ
-  VERSION = '0.2.2'
+  VERSION = '0.2.3'
 end

--- a/ruby-jq.gemspec
+++ b/ruby-jq.gemspec
@@ -13,6 +13,7 @@ Gem::Specification.new do |spec|
   spec.summary       = 'Ruby bindings for jq'
   spec.homepage      = 'https://github.com/winebarrel/ruby-jq'
   spec.license       = 'MIT'
+  spec.required_ruby_version = '>= 2.7'
 
   spec.files         = `git ls-files`.split($INPUT_RECORD_SEPARATOR)
   spec.extensions    = 'ext/extconf.rb'

--- a/ruby-jq.gemspec
+++ b/ruby-jq.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |spec|
   spec.version       = JQ::VERSION
   spec.author        = 'winebarrel'
   spec.email         = 'sgwr_dts@yahoo.co.jp'
-  spec.description   = 'Ruby bindings for jq'
+  spec.description   = 'Ruby bindings for jq, lightweight and flexible JSON processor'
   spec.summary       = 'Ruby bindings for jq'
   spec.homepage      = 'https://github.com/winebarrel/ruby-jq'
   spec.license       = 'MIT'
@@ -20,11 +20,11 @@ Gem::Specification.new do |spec|
   # spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'multi_json'
-  spec.add_runtime_dependency 'mini_portile2', '>= 2.2.0'
+  spec.add_dependency 'multi_json', '~> 1.15', '>= 1.10.0'
+  spec.add_runtime_dependency 'mini_portile2', '~> 2.2', '>= 2.2.0'
 
-  spec.add_development_dependency 'rake'
-  spec.add_development_dependency 'rake-compiler'
-  spec.add_development_dependency 'rspec'
-  spec.add_development_dependency 'rubocop'
+  spec.add_development_dependency 'rake', '~> 0'
+  spec.add_development_dependency 'rake-compiler', '~> 0'
+  spec.add_development_dependency 'rspec', '~> 0'
+  spec.add_development_dependency 'rubocop', '~> 0'
 end

--- a/ruby-jq.gemspec
+++ b/ruby-jq.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'multi_json', '~> 1.15', '>= 1.10.0'
-  spec.add_runtime_dependency 'mini_portile2', '~> 2.2', '>= 2.2.0'
+  spec.add_runtime_dependency 'mini_portile2', '~> 2.8', '>= 2.8.1'
 
   spec.add_development_dependency 'rake', '~> 0.9.6'
   spec.add_development_dependency 'rake-compiler', '~> 0.9.9'

--- a/ruby-jq.gemspec
+++ b/ruby-jq.gemspec
@@ -23,8 +23,8 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'multi_json', '~> 1.15', '>= 1.10.0'
   spec.add_runtime_dependency 'mini_portile2', '~> 2.2', '>= 2.2.0'
 
-  spec.add_development_dependency 'rake', '~> 0'
-  spec.add_development_dependency 'rake-compiler', '~> 0'
-  spec.add_development_dependency 'rspec', '~> 0'
-  spec.add_development_dependency 'rubocop', '~> 0'
+  spec.add_development_dependency 'rake', '~> 0.9.6'
+  spec.add_development_dependency 'rake-compiler', '~> 0.9.9'
+  spec.add_development_dependency 'rspec', '~> 3.9.0'
+  spec.add_development_dependency 'rubocop', '~> 0.93.1'
 end


### PR DESCRIPTION
Archive changed to release as it includes the dependency for oniguruma. Otherwise a compile error occurs because the source does not exist in the jq/modules directory.

Changed autoreconf due to a known bug in the last jq release. https://github.com/stedolan/jq/issues/1778
